### PR TITLE
Added Dockerfile

### DIFF
--- a/DockerFile
+++ b/DockerFile
@@ -1,0 +1,29 @@
+# Use the official .NET 8 SDK image to build the app
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Copy csproj and restore as distinct layers
+COPY *.csproj ./
+RUN dotnet restore
+
+# Copy the rest of the source code
+COPY . ./
+
+# Build the application
+RUN dotnet publish -c Release -o /app/publish
+
+# Use the official ASP.NET runtime image for Blazor
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+WORKDIR /app
+
+# Copy the published output from the build stage
+COPY --from=build /app/publish .
+
+# Expose the default port (adjust if your app uses a different port)
+EXPOSE 8080
+
+# Set environment variables if needed (optional)
+# ENV ASPNETCORE_URLS=http://+:8080
+
+# Start the application
+ENTRYPOINT ["dotnet", "NL2SQL_Blazor.dll"]


### PR DESCRIPTION
This pull request introduces a new `DockerFile` to containerize the Blazor application using .NET 8 SDK and runtime images. The file sets up a multi-stage build process for efficient application building and deployment.

### Dockerization:

* [`DockerFile`](diffhunk://#diff-2e832330bd567e7177edf73bd1b0d7550f84448a2acb9ca2bc0d4dd89bd4a667R1-R29): Added a multi-stage Docker setup. The build stage uses the official .NET 8 SDK image to restore dependencies and publish the application, while the final stage uses the ASP.NET runtime image to host the Blazor app. It also exposes port 8080 and defines the entry point to start the application.